### PR TITLE
When running as standalone jar images are not served

### DIFF
--- a/leap-consent-ui/pom.xml
+++ b/leap-consent-ui/pom.xml
@@ -265,6 +265,7 @@
                     <execution>
                         <goals>
                             <goal>prepare-frontend</goal>
+                            <goal>build-frontend</goal>
                         </goals>
                     </execution>
                 </executions>


### PR DESCRIPTION
When running as standalone jar or war the application in production mode did not serve images, a missing goal was added in the build plugin