### PR TITLE
Correct how we create, reference, and search for consent

### DIFF
--- a/leap-consent-ui/src/main/java/gov/hhs/onc/leap/backend/fhir/client/utils/FHIRConsent.java
+++ b/leap-consent-ui/src/main/java/gov/hhs/onc/leap/backend/fhir/client/utils/FHIRConsent.java
@@ -38,7 +38,8 @@ public class FHIRConsent {
 
     public Collection<Consent> getPatientConsents() {
         ConsentSession consentSession = (ConsentSession)VaadinSession.getCurrent().getAttribute("consentSession");
-        String patientId = consentSession.getFhirPatient().getId();
+        //get just the id portion
+        String patientId = consentSession.getFhirPatient().getId().replace("Patient/", "");
         Collection<Consent> consentCollection = new ArrayList<>();
         Bundle bundle = hapiFhirServer.getAllConsentsForPatient(patientId);
         List<Bundle.BundleEntryComponent> resourceList = bundle.getEntry();

--- a/leap-consent-ui/src/main/java/gov/hhs/onc/leap/ui/views/DoNotResuscitate.java
+++ b/leap-consent-ui/src/main/java/gov/hhs/onc/leap/ui/views/DoNotResuscitate.java
@@ -644,7 +644,7 @@ public class DoNotResuscitate extends ViewFrame {
     private void createFHIRConsent() {
         Patient patient = consentSession.getFhirPatient();
         Consent dnrDirective = new Consent();
-        dnrDirective.setId("DNR-"+patient.getId());
+        dnrDirective.setId("DNR-"+patient.getId().replace("Patient/", ""));
         dnrDirective.setStatus(Consent.ConsentState.ACTIVE);
         CodeableConcept cConcept = new CodeableConcept();
         Coding coding = new Coding();
@@ -661,7 +661,7 @@ public class DoNotResuscitate extends ViewFrame {
         cList.add(cConceptCat);
         dnrDirective.setCategory(cList);
         Reference patientRef = new Reference();
-        patientRef.setReference("Patient/"+patient.getId());
+        patientRef.setReference(patient.getId());
         patientRef.setDisplay(patient.getName().get(0).getFamily()+", "+patient.getName().get(0).getGiven().get(0).toString());
         dnrDirective.setPatient(patientRef);
         List<Reference> refList = new ArrayList<>();
@@ -707,7 +707,7 @@ public class DoNotResuscitate extends ViewFrame {
     private Extension createDoNotResuscitateQuestionnaireResponse() {
         Extension extension = new Extension();
         extension.setUrl("http://sdhealthconnect.com/leap/adr/dnr");
-        extension.setValue(new StringType(consentSession.getFhirbase()+"QuestionnaireResponse/leap-dnr-"+consentSession.getFhirPatient().getId()));
+        extension.setValue(new StringType(consentSession.getFhirbase()+"QuestionnaireResponse/leap-dnr-"+consentSession.getFhirPatient().getId().replace("Patient/", "")));
         return extension;
     }
 
@@ -727,9 +727,9 @@ public class DoNotResuscitate extends ViewFrame {
         BooleanType booleanTypeFalse = new BooleanType(false);
         BooleanType answerBoolean = new BooleanType();
         questionnaireResponse = new QuestionnaireResponse();
-        questionnaireResponse.setId("leap-dnr-"+consentSession.getFhirPatient().getId());
+        questionnaireResponse.setId("leap-dnr-"+consentSession.getFhirPatient().getId().replace("Patient/", ""));
         Reference refpatient = new Reference();
-        refpatient.setReference("Patient/"+consentSession.getFhirPatient().getId());
+        refpatient.setReference(consentSession.getFhirPatient().getId());
         questionnaireResponse.setAuthor(refpatient);
         questionnaireResponse.setAuthored(new Date());
         questionnaireResponse.setStatus(QuestionnaireResponse.QuestionnaireResponseStatus.COMPLETED);

--- a/leap-consent-ui/src/main/java/gov/hhs/onc/leap/ui/views/HealthcarePowerOfAttorney.java
+++ b/leap-consent-ui/src/main/java/gov/hhs/onc/leap/ui/views/HealthcarePowerOfAttorney.java
@@ -1382,7 +1382,7 @@ public class HealthcarePowerOfAttorney extends ViewFrame {
     private void createFHIRConsent() {
         Patient patient = consentSession.getFhirPatient();
         Consent poaDirective = new Consent();
-        poaDirective.setId("POAHealthcare-"+patient.getId());
+        poaDirective.setId("POAHealthcare-"+patient.getId().replace("Patient/", ""));
         poaDirective.setStatus(Consent.ConsentState.ACTIVE);
         CodeableConcept cConcept = new CodeableConcept();
         Coding coding = new Coding();
@@ -1399,7 +1399,7 @@ public class HealthcarePowerOfAttorney extends ViewFrame {
         cList.add(cConceptCat);
         poaDirective.setCategory(cList);
         Reference patientRef = new Reference();
-        patientRef.setReference("Patient/"+patient.getId());
+        patientRef.setReference(patient.getId());
         patientRef.setDisplay(patient.getName().get(0).getFamily()+", "+patient.getName().get(0).getGiven().get(0).toString());
         poaDirective.setPatient(patientRef);
         List<Reference> refList = new ArrayList<>();
@@ -1444,7 +1444,7 @@ public class HealthcarePowerOfAttorney extends ViewFrame {
     private Extension createHealthcarePowerOfAttorneyQuestionnaireResponse() {
         Extension extension = new Extension();
         extension.setUrl("http://sdhealthconnect.com/leap/adr/poahealthcare");
-        extension.setValue(new StringType(consentSession.getFhirbase()+"QuestionnaireResponse/leap-poahealthcare-"+consentSession.getFhirPatient().getId()));
+        extension.setValue(new StringType(consentSession.getFhirbase()+"QuestionnaireResponse/leap-poahealthcare-"+consentSession.getFhirPatient().getId().replace("Patient/", "")));
         return extension;
     }
 
@@ -1493,9 +1493,9 @@ public class HealthcarePowerOfAttorney extends ViewFrame {
 
     private void createQuestionnaireResponse() {
         questionnaireResponse = new QuestionnaireResponse();
-        questionnaireResponse.setId("leap-poahealthcare-" + consentSession.getFhirPatient().getId());
+        questionnaireResponse.setId("leap-poahealthcare-" + consentSession.getFhirPatient().getId().replace("Patient/", ""));
         Reference refpatient = new Reference();
-        refpatient.setReference("Patient/" + consentSession.getFhirPatient().getId());
+        refpatient.setReference(consentSession.getFhirPatient().getId());
         questionnaireResponse.setAuthor(refpatient);
         questionnaireResponse.setAuthored(new Date());
         questionnaireResponse.setStatus(QuestionnaireResponse.QuestionnaireResponseStatus.COMPLETED);

--- a/leap-consent-ui/src/main/java/gov/hhs/onc/leap/ui/views/LivingWill.java
+++ b/leap-consent-ui/src/main/java/gov/hhs/onc/leap/ui/views/LivingWill.java
@@ -839,7 +839,7 @@ public class LivingWill extends ViewFrame {
     private void createFHIRConsent() {
         Patient patient = consentSession.getFhirPatient();
         Consent poaDirective = new Consent();
-        poaDirective.setId("LivingWill-"+patient.getId());
+        poaDirective.setId("LivingWill-"+patient.getId().replace("Patient/", ""));
         poaDirective.setStatus(Consent.ConsentState.ACTIVE);
         CodeableConcept cConcept = new CodeableConcept();
         Coding coding = new Coding();
@@ -856,7 +856,7 @@ public class LivingWill extends ViewFrame {
         cList.add(cConceptCat);
         poaDirective.setCategory(cList);
         Reference patientRef = new Reference();
-        patientRef.setReference("Patient/"+patient.getId());
+        patientRef.setReference(patient.getId());
         patientRef.setDisplay(patient.getName().get(0).getFamily()+", "+patient.getName().get(0).getGiven().get(0).toString());
         poaDirective.setPatient(patientRef);
         List<Reference> refList = new ArrayList<>();
@@ -901,7 +901,7 @@ public class LivingWill extends ViewFrame {
     private Extension createLivingWillQuestionnaireResponse() {
         Extension extension = new Extension();
         extension.setUrl("http://sdhealthconnect.com/leap/adr/livingwill");
-        extension.setValue(new StringType(consentSession.getFhirbase()+"QuestionnaireResponse/leap-livingwill-"+consentSession.getFhirPatient().getId()));
+        extension.setValue(new StringType(consentSession.getFhirbase()+"QuestionnaireResponse/leap-livingwill-"+consentSession.getFhirPatient().getId().replace("Patient/","")));
         return extension;
     }
 
@@ -928,9 +928,9 @@ public class LivingWill extends ViewFrame {
 
     private void createQuestionnaireResponse() {
         questionnaireResponse = new QuestionnaireResponse();
-        questionnaireResponse.setId("leap-livingwill-" + consentSession.getFhirPatient().getId());
+        questionnaireResponse.setId("leap-livingwill-" + consentSession.getFhirPatient().getId().replace("Patient/", ""));
         Reference refpatient = new Reference();
-        refpatient.setReference("Patient/" + consentSession.getFhirPatient().getId());
+        refpatient.setReference(consentSession.getFhirPatient().getId());
         questionnaireResponse.setAuthor(refpatient);
         questionnaireResponse.setAuthored(new Date());
         questionnaireResponse.setStatus(QuestionnaireResponse.QuestionnaireResponseStatus.COMPLETED);

--- a/leap-consent-ui/src/main/java/gov/hhs/onc/leap/ui/views/MentalHealthPowerOfAttorney.java
+++ b/leap-consent-ui/src/main/java/gov/hhs/onc/leap/ui/views/MentalHealthPowerOfAttorney.java
@@ -968,7 +968,7 @@ public class MentalHealthPowerOfAttorney extends ViewFrame {
     private void createFHIRConsent() {
         Patient patient = consentSession.getFhirPatient();
         Consent poaDirective = new Consent();
-        poaDirective.setId("POAMentalHealth-"+patient.getId());
+        poaDirective.setId("POAMentalHealth-"+patient.getId().replace("Patient/", ""));
         poaDirective.setStatus(Consent.ConsentState.ACTIVE);
         CodeableConcept cConcept = new CodeableConcept();
         Coding coding = new Coding();
@@ -985,7 +985,7 @@ public class MentalHealthPowerOfAttorney extends ViewFrame {
         cList.add(cConceptCat);
         poaDirective.setCategory(cList);
         Reference patientRef = new Reference();
-        patientRef.setReference("Patient/"+patient.getId());
+        patientRef.setReference(patient.getId());
         patientRef.setDisplay(patient.getName().get(0).getFamily()+", "+patient.getName().get(0).getGiven().get(0).toString());
         poaDirective.setPatient(patientRef);
         List<Reference> refList = new ArrayList<>();
@@ -1030,7 +1030,7 @@ public class MentalHealthPowerOfAttorney extends ViewFrame {
     private Extension createPowerOfAttorneyMentalHealthQuestionnaireResponse() {
         Extension extension = new Extension();
         extension.setUrl("http://sdhealthconnect.com/leap/adr/poamentalhealth");
-        extension.setValue(new StringType(consentSession.getFhirbase()+"QuestionnaireResponse/leap-poamentalhealth-"+consentSession.getFhirPatient().getId()));
+        extension.setValue(new StringType(consentSession.getFhirbase()+"QuestionnaireResponse/leap-poamentalhealth-"+consentSession.getFhirPatient().getId().replace("Patient/", "")));
         return extension;
     }
 
@@ -1073,9 +1073,9 @@ public class MentalHealthPowerOfAttorney extends ViewFrame {
         BooleanType booleanTypeFalse = new BooleanType(false);
         BooleanType answerBoolean = new BooleanType();
         questionnaireResponse = new QuestionnaireResponse();
-        questionnaireResponse.setId("leap-poamentalhealth-" + consentSession.getFhirPatient().getId());
+        questionnaireResponse.setId("leap-poamentalhealth-" + consentSession.getFhirPatient().getId().replace("Patient/", ""));
         Reference refpatient = new Reference();
-        refpatient.setReference("Patient/" + consentSession.getFhirPatient().getId());
+        refpatient.setReference(consentSession.getFhirPatient().getId());
         questionnaireResponse.setAuthor(refpatient);
         questionnaireResponse.setAuthored(new Date());
         questionnaireResponse.setStatus(QuestionnaireResponse.QuestionnaireResponseStatus.COMPLETED);

--- a/leap-consent-ui/src/main/java/gov/hhs/onc/leap/ui/views/PortableMedicalOrder.java
+++ b/leap-consent-ui/src/main/java/gov/hhs/onc/leap/ui/views/PortableMedicalOrder.java
@@ -1482,7 +1482,7 @@ public class PortableMedicalOrder extends ViewFrame {
     private void createFHIRConsent() {
         Patient patient = consentSession.getFhirPatient();
         Consent polstDirective = new Consent();
-        polstDirective.setId("POLST-"+patient.getId());
+        polstDirective.setId("POLST-"+patient.getId().replace("Patient/", ""));
         polstDirective.setStatus(Consent.ConsentState.ACTIVE);
         CodeableConcept cConcept = new CodeableConcept();
         Coding coding = new Coding();
@@ -1499,7 +1499,7 @@ public class PortableMedicalOrder extends ViewFrame {
         cList.add(cConceptCat);
         polstDirective.setCategory(cList);
         Reference patientRef = new Reference();
-        patientRef.setReference("Patient/"+patient.getId());
+        patientRef.setReference(patient.getId());
         patientRef.setDisplay(patient.getName().get(0).getFamily()+", "+patient.getName().get(0).getGiven().get(0).toString());
         polstDirective.setPatient(patientRef);
         List<Reference> refList = new ArrayList<>();
@@ -1544,7 +1544,7 @@ public class PortableMedicalOrder extends ViewFrame {
     private Extension createPortableMedicalOrderQuestionnaireResponse() {
         Extension extension = new Extension();
         extension.setUrl("http://sdhealthconnect.com/leap/adr/polst");
-        extension.setValue(new StringType(consentSession.getFhirbase()+"QuestionnaireResponse/leap-polst-"+consentSession.getFhirPatient().getId()));
+        extension.setValue(new StringType(consentSession.getFhirbase()+"QuestionnaireResponse/leap-polst-"+consentSession.getFhirPatient().getId().replace("Patient/", "")));
         return extension;
     }
 
@@ -1607,9 +1607,9 @@ public class PortableMedicalOrder extends ViewFrame {
 
     private void createQuestionnaireResponse() {
         questionnaireResponse = new QuestionnaireResponse();
-        questionnaireResponse.setId("leap-polst-" + consentSession.getFhirPatient().getId());
+        questionnaireResponse.setId("leap-polst-" + consentSession.getFhirPatient().getId().replace("Patient/", ""));
         Reference refpatient = new Reference();
-        refpatient.setReference("Patient/" + consentSession.getFhirPatient().getId());
+        refpatient.setReference(consentSession.getFhirPatient().getId());
         questionnaireResponse.setAuthor(refpatient);
         questionnaireResponse.setAuthored(new Date());
         questionnaireResponse.setStatus(QuestionnaireResponse.QuestionnaireResponseStatus.COMPLETED);

--- a/leap-consent-ui/src/main/java/gov/hhs/onc/leap/ui/views/SharePatientDataView.java
+++ b/leap-consent-ui/src/main/java/gov/hhs/onc/leap/ui/views/SharePatientDataView.java
@@ -757,7 +757,7 @@ public class SharePatientDataView extends ViewFrame {
 
         //set patient ref
         Reference patientRef = new Reference();
-        patientRef.setReference("Patient/"+patient.getId().replace(fhirBase, ""));
+        patientRef.setReference(patient.getId().replace(fhirBase, ""));
         patientRef.setDisplay(patient.getName().get(0).getFamily()+", "+patient.getName().get(0).getGiven().get(0).toString());
         patientPrivacyConsent.setPatient(patientRef);
 


### PR DESCRIPTION
When using patient.getId ... the resource reference is returned, example Patient/2035, this change corrects our use of id portion only.  