### PR TITLE
Completes end-to-end functionality.

### DIFF
--- a/leap-consent-ui/src/main/java/gov/hhs/onc/leap/ui/views/SharePatientDataView.java
+++ b/leap-consent-ui/src/main/java/gov/hhs/onc/leap/ui/views/SharePatientDataView.java
@@ -111,7 +111,7 @@ public class SharePatientDataView extends ViewFrame {
 
     @PostConstruct
     public void setup() {
-        setId("sharePatientDataView");
+        setId("sharepatientdataView");
         setViewContent(createViewContent());
         setViewFooter(getFooter());
     }


### PR DESCRIPTION
Provides navigation to required questionnaire/form for completion.  

This is a listing of user consent requirements, ideally this is read in from a properties file or db based on the user's primary state's requirements and may require evaluation of patient's age and other demographic or conditional info.  For demonstration purposes those rules/requirements are set within class.

Available for QA.