### PR TITLE
Set the maximum file size upload to 5MB

### DIFF
--- a/leap-consent-ui/application.properties
+++ b/leap-consent-ui/application.properties
@@ -1,0 +1,6 @@
+server.port=8080
+spring.servlet.multipart.max-file-size=5MB
+spring.servlet.multipart.max-request-size=5MB
+vaadin.pnpm.enabled=true
+server.tomcat.max-swallow-size=10MB
+

--- a/leap-consent-ui/applications.properties
+++ b/leap-consent-ui/applications.properties
@@ -1,4 +1,0 @@
-server.port=8080
-spring.servlet.multipart.max-file-size=-1
-spring.servlet.multipart.max-request-size=-1
-vaadin.pnpm.enabled=true


### PR DESCRIPTION
Set the maximum file size that spring boot can handle in a MultipartFile to 5MB