### PR TITLE
updating vaadin and pdfbox per security alert.

### DIFF
--- a/leap-consent-ui/pom.xml
+++ b/leap-consent-ui/pom.xml
@@ -22,7 +22,7 @@
         <failOnMissingWebXml>false</failOnMissingWebXml>
         <pnpmEnabled>true</pnpmEnabled>
 
-        <vaadin.version>19.0.4</vaadin.version>
+        <vaadin.version>19.0.9</vaadin.version>
         <!--<jetty.version>9.4.15.v20190215</jetty.version> -->
 
         <!-- The liquibase version should match the one managed by
@@ -202,7 +202,7 @@
         <dependency>
             <groupId>org.apache.pdfbox</groupId>
             <artifactId>pdfbox</artifactId>
-            <version>2.0.23</version>
+            <version>2.0.24</version>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>


### PR DESCRIPTION
This is a minor upgrade to address the security alert raised by dependency versions.